### PR TITLE
Prettier 3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,14 @@
 			],
 			"devDependencies": {}
 		},
+		"node_modules/@aashutoshrathi/word-wrap": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
@@ -224,13 +232,13 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-			"integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
+			"integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.5.2",
+				"espree": "^9.6.0",
 				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -246,9 +254,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
-			"integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
+			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
+			"integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -762,16 +770,16 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.60.0.tgz",
-			"integrity": "sha512-78B+anHLF1TI8Jn/cD0Q00TBYdMgjdOn980JfAVa9yw5sop8nyTfVOQAv6LWywkOGLclDBtv5z3oxN4w7jxyNg==",
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.61.0.tgz",
+			"integrity": "sha512-A5l/eUAug103qtkwccSCxn8ZRwT+7RXWkFECdA4Cvl1dOlDUgTpAOfSEElZn2uSUxhdDpnCdetrf0jvU4qrL+g==",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.60.0",
-				"@typescript-eslint/type-utils": "5.60.0",
-				"@typescript-eslint/utils": "5.60.0",
+				"@typescript-eslint/scope-manager": "5.61.0",
+				"@typescript-eslint/type-utils": "5.61.0",
+				"@typescript-eslint/utils": "5.61.0",
 				"debug": "^4.3.4",
-				"grapheme-splitter": "^1.0.4",
+				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
 				"natural-compare-lite": "^1.4.0",
 				"semver": "^7.3.7",
@@ -792,6 +800,50 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.61.0.tgz",
+			"integrity": "sha512-W8VoMjoSg7f7nqAROEmTt6LoBpn81AegP7uKhhW5KzYlehs8VV0ZW0fIDVbcZRcaP3aPSW+JZFua+ysQN+m/Nw==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.61.0",
+				"@typescript-eslint/visitor-keys": "5.61.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.61.0.tgz",
+			"integrity": "sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.61.0.tgz",
+			"integrity": "sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.61.0",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
@@ -825,6 +877,7 @@
 			"version": "5.60.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.60.0.tgz",
 			"integrity": "sha512-hakuzcxPwXi2ihf9WQu1BbRj1e/Pd8ZZwVTG9kfbxAMZstKz8/9OoexIwnmLzShtsdap5U/CoQGRCWlSuPbYxQ==",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "5.60.0",
 				"@typescript-eslint/visitor-keys": "5.60.0"
@@ -838,12 +891,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.60.0.tgz",
-			"integrity": "sha512-X7NsRQddORMYRFH7FWo6sA9Y/zbJ8s1x1RIAtnlj6YprbToTiQnM6vxcMu7iYhdunmoC0rUWlca13D5DVHkK2g==",
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.61.0.tgz",
+			"integrity": "sha512-kk8u//r+oVK2Aj3ph/26XdH0pbAkC2RiSjUYhKD+PExemG4XSjpGFeyZ/QM8lBOa7O8aGOU+/yEbMJgQv/DnCg==",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.60.0",
-				"@typescript-eslint/utils": "5.60.0",
+				"@typescript-eslint/typescript-estree": "5.61.0",
+				"@typescript-eslint/utils": "5.61.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			},
@@ -863,10 +916,65 @@
 				}
 			}
 		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.61.0.tgz",
+			"integrity": "sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.61.0.tgz",
+			"integrity": "sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.61.0",
+				"@typescript-eslint/visitor-keys": "5.61.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.61.0.tgz",
+			"integrity": "sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.61.0",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
 		"node_modules/@typescript-eslint/types": {
 			"version": "5.60.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.60.0.tgz",
 			"integrity": "sha512-ascOuoCpNZBccFVNJRSC6rPq4EmJ2NkuoKnd6LDNyAQmdDnziAtxbCGWCbefG1CNzmDvd05zO36AmB7H8RzKPA==",
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -879,6 +987,7 @@
 			"version": "5.60.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.60.0.tgz",
 			"integrity": "sha512-R43thAuwarC99SnvrBmh26tc7F6sPa2B3evkXp/8q954kYL6Ro56AwASYWtEEi+4j09GbiNAHqYwNNZuNlARGQ==",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "5.60.0",
 				"@typescript-eslint/visitor-keys": "5.60.0",
@@ -902,16 +1011,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.60.0.tgz",
-			"integrity": "sha512-ba51uMqDtfLQ5+xHtwlO84vkdjrqNzOnqrnwbMHMRY8Tqeme8C2Q8Fc7LajfGR+e3/4LoYiWXUM6BpIIbHJ4hQ==",
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.61.0.tgz",
+			"integrity": "sha512-mV6O+6VgQmVE6+xzlA91xifndPW9ElFW8vbSF0xCT/czPXVhwDewKila1jOyRwa9AE19zKnrr7Cg5S3pJVrTWQ==",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@types/json-schema": "^7.0.9",
 				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.60.0",
-				"@typescript-eslint/types": "5.60.0",
-				"@typescript-eslint/typescript-estree": "5.60.0",
+				"@typescript-eslint/scope-manager": "5.61.0",
+				"@typescript-eslint/types": "5.61.0",
+				"@typescript-eslint/typescript-estree": "5.61.0",
 				"eslint-scope": "^5.1.1",
 				"semver": "^7.3.7"
 			},
@@ -926,10 +1035,81 @@
 				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.61.0.tgz",
+			"integrity": "sha512-W8VoMjoSg7f7nqAROEmTt6LoBpn81AegP7uKhhW5KzYlehs8VV0ZW0fIDVbcZRcaP3aPSW+JZFua+ysQN+m/Nw==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.61.0",
+				"@typescript-eslint/visitor-keys": "5.61.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.61.0.tgz",
+			"integrity": "sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.61.0.tgz",
+			"integrity": "sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.61.0",
+				"@typescript-eslint/visitor-keys": "5.61.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.61.0.tgz",
+			"integrity": "sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==",
+			"dependencies": {
+				"@typescript-eslint/types": "5.61.0",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
 		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "5.60.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.60.0.tgz",
 			"integrity": "sha512-wm9Uz71SbCyhUKgcaPRauBdTegUyY/ZWl8gLwD/i/ybJqscrrdVSFImpvUz16BLPChIeKBK5Fa9s6KDQjsjyWw==",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "5.60.0",
 				"eslint-visitor-keys": "^3.3.0"
@@ -1820,14 +2000,14 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
-			"integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
+			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
+			"integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.4.0",
-				"@eslint/eslintrc": "^2.0.3",
-				"@eslint/js": "8.43.0",
+				"@eslint/eslintrc": "^2.1.0",
+				"@eslint/js": "8.44.0",
 				"@humanwhocodes/config-array": "^0.11.10",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -1839,7 +2019,7 @@
 				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^7.2.0",
 				"eslint-visitor-keys": "^3.4.1",
-				"espree": "^9.5.2",
+				"espree": "^9.6.0",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -1859,7 +2039,7 @@
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.1",
+				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
@@ -2006,9 +2186,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "46.2.6",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.2.6.tgz",
-			"integrity": "sha512-zIaK3zbSrKuH12bP+SPybPgcHSM6MFzh3HFeaODzmsF1N8C1l8dzJ22cW1aq4g0+nayU1VMjmNf7hg0dpShLrA==",
+			"version": "46.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.3.tgz",
+			"integrity": "sha512-Prc7ol+vCIghPeECpwZq5+P+VZfoi87suywvbYCiCnkI1kTmVSdcOC2M8mioglWxBbd28wbb1OVjg/8OzGzatA==",
 			"dependencies": {
 				"@es-joy/jsdoccomment": "~0.39.4",
 				"are-docs-informative": "^0.0.2",
@@ -2074,11 +2254,11 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.5.2",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-			"integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+			"version": "9.6.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
+			"integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
 			"dependencies": {
-				"acorn": "^8.8.0",
+				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
 				"eslint-visitor-keys": "^3.4.1"
 			},
@@ -2667,11 +2847,6 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true
-		},
-		"node_modules/grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -3941,16 +4116,16 @@
 			}
 		},
 		"node_modules/optionator": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+			"integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
 			"dependencies": {
+				"@aashutoshrathi/word-wrap": "^1.2.3",
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
-				"type-check": "^0.4.0",
-				"word-wrap": "^1.2.3"
+				"type-check": "^0.4.0"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -5440,14 +5615,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/wrap-ansi": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -5597,12 +5764,12 @@
 			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "^5.60.0",
+				"@typescript-eslint/eslint-plugin": "^5.61.0",
 				"eslint-config-airbnb-base": "^15.0.0",
-				"eslint-plugin-jsdoc": "^46.2.6"
+				"eslint-plugin-jsdoc": "^46.4.3"
 			},
 			"devDependencies": {
-				"eslint": "^8.43.0"
+				"eslint": "^8.44.0"
 			},
 			"peerDependencies": {
 				"eslint": "^8.39.0"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,15 +22,15 @@
 		"test": "eslint __tests__/*"
 	},
 	"dependencies": {
-		"@typescript-eslint/eslint-plugin": "^5.60.0",
+		"@typescript-eslint/eslint-plugin": "^5.61.0",
 		"eslint-config-airbnb-base": "^15.0.0",
-		"eslint-plugin-jsdoc": "^46.2.6"
+		"eslint-plugin-jsdoc": "^46.4.3"
 	},
 	"devDependencies": {
-		"eslint": "^8.43.0"
+		"eslint": "^8.44.0"
 	},
 	"peerDependencies": {
-		"eslint": "^8.39.0"
+		"eslint": "^8.44.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/eslint-config/rules/eslint/layout&formatting.js
+++ b/packages/eslint-config/rules/eslint/layout&formatting.js
@@ -1,15 +1,6 @@
 module.exports = {
 	rules: {
-		'comma-dangle': [
-			'error',
-			{
-				arrays: 'always-multiline',
-				objects: 'always-multiline',
-				imports: 'always-multiline',
-				exports: 'always-multiline',
-				functions: 'never',
-			},
-		],
+		'comma-dangle': ['error', 'always-multiline'],
 		'function-paren-newline': 'off',
 		'implicit-arrow-linebreak': 'off',
 		indent: [


### PR DESCRIPTION
The following changes are in Breaking Changes; [Change the default value for `trailingComma` to `all`](https://prettier.io/blog/2023/07/05/3.0.0.html#change-the-default-value-for-trailingcomma-to-all-11479httpsgithubcomprettierprettierpull11479-by-fiskerhttpsgithubcomfisker-13143httpsgithubcomprettierprettierpull13143-by-sosukesuzukihttpsgithubcomsosukesuzuki)

Therefore, unify all [`comma-dangle`](https://eslint.org/docs/latest/rules/comma-dangle) rules to `always-multiline`.